### PR TITLE
Add healpix script

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ install_requires =
     # List your requirements here
     astropy
     h5py
+    healpy
     numba
     numpy
     pandas
@@ -34,3 +35,4 @@ include_package_data=True
 [options.entry_points]
 console_scripts =
     ananke-make-catalog = ananke.bin.make_catalog:main
+    ananke-make-aux = ananke.bin.add_healpix:main

--- a/src/ananke/bin/add_healpix.py
+++ b/src/ananke/bin/add_healpix.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import time
+
+import h5py
+import numpy as np
+import healpy as hp
+
+from ananke import io, config
+from ananke.logger import logger
+
+def parse_cmd():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--gal', required=True, type=str,
+                         help='Galaxy name of run')
+    parser.add_argument('--lsr', required=True, type=int,
+                        help='LSR number of run')
+    parser.add_argument('--rslice', required=True, type=int,
+                        help='Radial slice of run')
+    parser.add_argument('--nside', required=True, type=int,
+                        help='Nside of Healpix map')
+    parser.add_argument('--ijob', type=int, default=0, help='Job index')
+    parser.add_argument('--Njob', type=int, default=1, help='Total number of jobs')
+    parser.add_argument('--batch-size', required=False, type=int, default=1000000,
+                        help='Batch size')
+    return parser.parse_args()
+
+def main():
+    """ Calculate and write healpix index """
+    FLAGS = parse_cmd()
+
+    gal = FLAGS.gal
+    lsr = FLAGS.lsr
+    rslice = FLAGS.rslice
+
+    ## Start script
+
+    # get file information from galaxy, lsr, and rslice
+    in_path = os.path.join(
+        config.DR3_BASEDIR, f"{gal}/lsr-{lsr}",
+        f"lsr-{lsr}-rslice-{rslice}.{gal}-res7100-md-sliced-gcat-dr3.{FLAGS.ijob}.hdf5")
+    out_path = os.path.join(
+        config.DR3_BASEDIR, f"{gal}/lsr-{lsr}",
+        f"aux-lsr-{lsr}-rslice-{rslice}.{gal}-res7100-md-sliced-gcat-dr3.{FLAGS.ijob}.hdf5")
+
+    # create output directory if not already exists
+    os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+    # Apply G magnitude cut to the mock catalog
+    logger.info('Calculating Healpix index:')
+    logger.info(f'In  : {in_path}')
+    logger.info(f'Dest: {out_path}')
+
+    out_f = h5py.File(out_path, 'w')
+    with h5py.File(in_path, 'r') as in_f:
+        N = len(in_f['dmod_true'])
+        N_batch = (N + FLAGS.batch_size - 1) // FLAGS.batch_size
+
+        for i_batch in range(N_batch):
+            logger.info(f'Progress [{i_batch}/{N_batch}]')
+            i_start = i_batch * FLAGS.batch_size
+            i_stop = i_start + FLAGS.batch_size
+
+            # Load the RA and DEC datasets
+            ra = in_f['ra'][i_start: i_stop]
+            dec = in_f['dec'][i_start: i_stop]
+
+            # Compute the HEALPIX pixel indices for Nside; nested
+            nside = FLAGS.nside
+            theta = np.radians(90.0 - dec)
+            phi = np.radians(ra)
+            pix = hp.ang2pix(nside, theta, phi, nest=True)
+
+            # Add the pixel index dataset to the HDF5 file
+            io.append_dataset(out_f, f"pix{nside}", pix)
+    out_f.close()
+
+if __name__ == "__main__":
+    # run main and keep track of time
+    t0 = time.time()
+    main()
+    t1 = time.time()
+    logger.info(f"Total run time: {t1 - t0}")
+    logger.info("Done!")


### PR DESCRIPTION
I added the script to /bin as you suggested. I have the script write the healpix index to a separate file called aux-{full file name}.{ijob}.hdf5 and stored in the same final ananke_dr3 directory. 

I'm uncertain if I should make this an executable like make-ananke-catalog. The way it is written now, the script can work by calling make-ananke-aux, similar to make-ananke-catalog, but the timing part won't work since it's outside of main(). This feels very much not ideal, so let me know what I should do.

I did a test run on m12i-lsr0-rslice0.0.hdf5 and the numbers all make sense. 